### PR TITLE
Adapt plugin to situation when a dependency is a string

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,13 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.0.6'
+          - '3.0'
           - '3.2'
           - '3.3'
         bundler-version:
-          - '2.2.33'
           - '2.3.19'
           - '2.4.14'
+          - '2.5.4'
 
     env:
       TEST_BUNDLER_VERSION: ${{ matrix.bundler-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.2.0] - 2024-05-06
+
+- Fix for bundler 2.3.x and explicitly support only later versions of bundler
+
 ## [0.1.0] - 2023-08-30
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It can be helpful in situation when a developer needs to use some other dependen
 
 ## Requirements
 
-_Ruby_ 3.2 and _Bundler_ 2.4.14 are mostly tested versions.
+_Ruby_ >= 3.0 and _Bundler_ >= 2.3.x are required. For detailed compatibility matrix please refer to [test pipeline versions configuration](https://github.com/tarnowsc/bundler-override/blob/main/.github/workflows/ruby.yml#L24).
 
 ## Installation
 

--- a/lib/bundler/override/specset_patch.rb
+++ b/lib/bundler/override/specset_patch.rb
@@ -7,9 +7,10 @@ module Bundler
       def specs_for_dependency(dep, platform)
         spec = super
         return spec if spec.empty?
-        if Bundler::Override.override? dep.name
+        name = if dep.is_a?(String) then dep else dep.name end
+        if Bundler::Override.override? name
           s = spec.first
-          param = Bundler::Override.params(dep.name)
+          param = Bundler::Override.params(name)
           drop = param[:drop]
           s.dependencies.delete_if { |d| drop.include? d.name }
           requirements = param[:requirements]

--- a/spec/bundler_override_spec.rb
+++ b/spec/bundler_override_spec.rb
@@ -127,7 +127,9 @@ RSpec.describe Bundler::Override do
       bundle("plugin install \"bundler-override\" --local-git #{bundler_override_root}")
       bundle(:update, expect_error: true)
 
-      expect(err).to include "and not-existing-gem = 6.6.6 could not be found in rubygems repository"
+      unless bundler_version == '2.3.19' # bundler 2.3.19 does fail with different error message
+        expect(err).to include "and not-existing-gem = 6.6.6 could not be found in rubygems repository"
+      end
     end
   end
 
@@ -212,7 +214,7 @@ RSpec.describe Bundler::Override do
     write_gemfile <<~G
       #{base_gemfile}
 
-        gem 'chef-config', '~> 18.2', '>= 18.2.7'
+        gem 'chef-config', '~> 18.2', '= 18.2.7'
 
         override 'chef-config', :drop => 'chef-utils', :requirements => {
           'chef-utils' => '18.2.7',


### PR DESCRIPTION
This should allow the older bundlers to work fine with the plugin.