### PR TITLE
Dont `require` inside install

### DIFF
--- a/lib/bundler-override.rb
+++ b/lib/bundler-override.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 require "set"
+
+require "bundler/friendly_errors"
+
 require_relative "bundler/override/dsl_patch"
 require_relative "bundler/override/dependency_patch"
-require "bundler/friendly_errors.rb"
 
 module Bundler
   module Override

--- a/lib/bundler-override.rb
+++ b/lib/bundler-override.rb
@@ -31,6 +31,22 @@ end
 require_relative "bundler/override/dependency_patch"
 require_relative "bundler/override/dsl_patch"
 
+module Bundler
+  class RemoteSpecification
+    include Override::DependencyPatch
+  end
+
+  class EndpointSpecification
+    include Override::DependencyPatch
+  end
+end
+
+module Gem
+  class Specification
+    include Bundler::Override::DependencyPatch
+  end
+end
+
 Bundler::Dsl.prepend(Bundler::Override::DslPatch)
 ObjectSpace.each_object(Bundler::Dsl) do |o|
   o.singleton_class.prepend(Bundler::Override::DslPatch)

--- a/lib/bundler-override.rb
+++ b/lib/bundler-override.rb
@@ -1,33 +1,7 @@
 # frozen_string_literal: true
-require "set"
-
 require "bundler/friendly_errors"
 
-module Bundler
-  module Override
-    class << self
-      def override?(name)
-        return unless @gems
-        @gems.include? name
-      end
-
-      def params(name)
-        return [] unless @gems
-        return [] unless @gems.include? name
-        @params.find { |o| o[:name] == name }
-      end
-
-      def add(name, drop, requirements)
-        @gems = Set.new unless @gems
-        return if @gems.include? name
-        @gems << name
-        @params = Array.new unless @params
-        @params << { :name => name, :drop => drop || [], :requirements => requirements }
-      end
-    end
-  end
-end
-
+require_relative "bundler/override"
 require_relative "bundler/override/dependency_patch"
 require_relative "bundler/override/dsl_patch"
 

--- a/lib/bundler-override.rb
+++ b/lib/bundler-override.rb
@@ -3,9 +3,6 @@ require "set"
 
 require "bundler/friendly_errors"
 
-require_relative "bundler/override/dsl_patch"
-require_relative "bundler/override/dependency_patch"
-
 module Bundler
   module Override
     class << self
@@ -30,6 +27,9 @@ module Bundler
     end
   end
 end
+
+require_relative "bundler/override/dependency_patch"
+require_relative "bundler/override/dsl_patch"
 
 Bundler::Dsl.prepend(Bundler::Override::DslPatch)
 ObjectSpace.each_object(Bundler::Dsl) do |o|

--- a/lib/bundler/override.rb
+++ b/lib/bundler/override.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require "set"
+
+module Bundler
+  module Override
+    class << self
+      def override?(name)
+        return unless @gems
+        @gems.include? name
+      end
+
+      def params(name)
+        return [] unless @gems
+        return [] unless @gems.include? name
+        @params.find { |o| o[:name] == name }
+      end
+
+      def add(name, drop, requirements)
+        @gems = Set.new unless @gems
+        return if @gems.include? name
+        @gems << name
+        @params = Array.new unless @params
+        @params << { :name => name, :drop => drop || [], :requirements => requirements }
+      end
+    end
+  end
+end

--- a/lib/bundler/override/dependency_patch.rb
+++ b/lib/bundler/override/dependency_patch.rb
@@ -36,19 +36,3 @@ module Bundler
     end
   end
 end
-
-module Bundler
-  class RemoteSpecification
-    include Override::DependencyPatch
-  end
-
-  class EndpointSpecification
-    include Override::DependencyPatch
-  end
-end
-
-module Gem
-  class Specification
-    include Bundler::Override::DependencyPatch
-  end
-end


### PR DESCRIPTION
Looks like to eat own dogfood while producing it is a bit questionable. The following `Gemfile`

```ruby
# frozen_string_literal: true

source "https://rubygems.org"

plugin "bundler-override", "= 0.4.0"
if Bundler::Plugin.installed?("bundler-override")
  require(File.join(Bundler::Plugin.index.load_paths("bundler-override")[0], "bundler-override"))

  override "resque", drop: ["sinatra"]
end

# gem specifications below
```

creates a `NoMethodError` for `Bundler::Override.override?` (for a `bundle exec rspec` call): 

```
'Gem::Specification#override_dependencies': undefined method 'override?' for module Bundler::Override (NoMethodError)
...
    # require "bundler/friendly_errors.rb"
    from /usr/local/bundle/plugin/gems/bundler-override-0.4.0/lib/bundler-override.rb:5:in '<top (required)>'
...
    # require(File.join(Bundler::Plugin.index.load_paths("bundler-override")[0], "bundler-override"))
    from /codebuild/output/src0000000000/src/Gemfile:7:in 'block in Bundler::Dsl#eval_gemfile'
...
```

This PR moves the "responsible" `require` out of the way. Plus it restructures the code to separate "compile code" from "wire into `Gem` and `Bundler`". 


### Full backtrace
```
/usr/local/bundle/plugin/gems/bundler-override-0.4.0/lib/bundler/override/dependency_patch.rb:18:in 'Gem::Specification#override_dependencies': undefined method 'override?' for module Bundler::Override (NoMethodError)
    from /usr/local/bundle/plugin/gems/bundler-override-0.4.0/lib/bundler/override/dependency_patch.rb:10:in 'Gem::Specification#dependencies'
    from /usr/local/lib/ruby/3.4.0/rubygems/specification.rb:2315:in 'Gem::Specification#runtime_dependencies'
    from /usr/local/bundle/plugin/gems/bundler-override-0.4.0/lib/bundler/override/dependency_patch.rb:14:in 'Gem::Specification#runtime_dependencies'
    from /usr/local/lib/ruby/3.4.0/rubygems/specification.rb:1664:in 'Gem::Specification#has_conflicts?'
    from /usr/local/lib/ruby/3.4.0/rubygems/specification.rb:2241:in 'Gem::Specification#raise_if_conflicts'
    from /usr/local/lib/ruby/3.4.0/rubygems/specification.rb:1387:in 'Gem::Specification#activate'
    from /usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_gem.rb:62:in 'block in Kernel#gem'
    from /usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_gem.rb:62:in 'Thread::Mutex#synchronize'
    from /usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_gem.rb:62:in 'Kernel#gem'
    from <internal:/usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:67:in 'block in Kernel#require'
    from <internal:/usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:39:in 'Monitor#synchronize'
    from <internal:/usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:39:in 'Kernel#require'
    from /usr/local/bundle/plugin/gems/bundler-override-0.4.0/lib/bundler-override.rb:5:in '<top (required)>'
    from <internal:/usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
    from <internal:/usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
    from /codebuild/output/src0000000000/src/Gemfile:7:in 'block in Bundler::Dsl#eval_gemfile'
    from /usr/local/lib/ruby/3.4.0/bundler/dsl.rb:47:in 'BasicObject#instance_eval'
    from /usr/local/lib/ruby/3.4.0/bundler/dsl.rb:47:in 'block in Bundler::Dsl#eval_gemfile'
    from /usr/local/lib/ruby/3.4.0/bundler/dsl.rb:315:in 'Bundler::Dsl#with_gemfile'
    from /usr/local/lib/ruby/3.4.0/bundler/dsl.rb:45:in 'Bundler::Dsl#eval_gemfile'
    from /usr/local/lib/ruby/3.4.0/bundler/dsl.rb:12:in 'Bundler::Dsl.evaluate'
    from /usr/local/lib/ruby/3.4.0/bundler/definition.rb:39:in 'Bundler::Definition.build'
    from /usr/local/lib/ruby/3.4.0/bundler.rb:237:in 'Bundler.definition'
    from /usr/local/lib/ruby/3.4.0/bundler.rb:161:in 'Bundler.setup'
    from /usr/local/lib/ruby/3.4.0/bundler/setup.rb:32:in 'block in <top (required)>'
    from /usr/local/lib/ruby/3.4.0/bundler/ui/shell.rb:173:in 'Bundler::UI::Shell#with_level'
    from /usr/local/lib/ruby/3.4.0/bundler/ui/shell.rb:119:in 'Bundler::UI::Shell#silence'
    from /usr/local/lib/ruby/3.4.0/bundler/setup.rb:32:in '<top (required)>'
    from <internal:/usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
    from <internal:/usr/local/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
    from /usr/local/lib/ruby/3.4.0/rubygems.rb:1417:in '<top (required)>'
    from <internal:gem_prelude>:2:in 'Kernel#require'
    from <internal:gem_prelude>:2:in '<internal:gem_prelude>'
```

This `Gemfile` code already helps to load the plugin successfully (predefines the method accessed by `require`):
```diff
-  require(File.join(Bundler::Plugin.index.load_paths("bundler-override")[0], "bundler-override"))
+  unless ::Bundler.const_defined?(:Override)
+    ::Bundler.const_set(:Override, Module.new do
+      def self.override?(*)
+        false
+      end
+    end)
+
+    require(File.join(::Bundler::Plugin.index.load_paths("bundler-override")[0], "bundler-override"))
+  end
```